### PR TITLE
Feature/coordinate transformation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,14 @@ The tool follows an automated workflow that generates some of the key files need
 1. **Model Loading** - Reads netCDF4 Earth models from IRIS EMC
 2. **Area Selection** - Interactive GUI or predefined UTM coordinates
 3. **3D Interpolation** - Trilinear interpolation onto regular grid
-4. **Tomography Files** - Generate SPECFEM3D-compatible `.xyz` files (raw text file)
+4. **Basis Transformation** - Transformation of anisotropic models to specfem3d_cartesian basis
+5. **Tomography Files** - Generate SPECFEM3D-compatible `.xyz` files (raw text file)
 
 Optionally, the workflow can include:
 
-5. **Topography Processing** - Extract and smooth surface topography 
-6. **Mesh Generation** - Create complete SPECFEM3D parameter files
-7. **Visualization** - Generate plots for validation and quality control
+6. **Topography Processing** - Extract and smooth surface topography 
+7. **Mesh Generation** - Create complete SPECFEM3D parameter files
+8. **Visualization** - Generate plots for validation and quality control
 
 
 ## Meshing helper

--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,6 @@ dependencies:
   - matplotlib
   - pip:
     - -e .
+    # Optional:
+    # for transforming anisotropic models to the specfem3d_cartesian basis
+    #- git+https://github.com/uafgeotools/elasticmapper.git

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,16 @@
 import setuptools
 from setuptools import find_packages, setup, Extension
 
+base_requirements=[
+    "numpy", "scipy", "pyproj",
+    "pandas", "cartopy", "netCDF4", "jinja2",
+    "ruamel.yaml", "requests", "scikit-learn", "matplotlib"
+]
+
+optional_requirements=[
+    "elasticmapper @ git+https://github.com/uafgeotools/elasticmapper.git"
+]
+
 setuptools.setup(
     name="specfem_tomo_helper", # Replace with your own username
     version="0.2.0",
@@ -26,11 +36,7 @@ setuptools.setup(
         "seismology"
     ],
     python_requires='~=3.6',
-    install_requires=[
-        "numpy", "scipy", "pyproj",
-        "pandas", "cartopy", "netCDF4", "jinja2",
-        "ruamel.yaml", "requests", "scikit-learn", "matplotlib"
-    ],
+    install_requires=base_requirements,
     entry_points={
         'console_scripts': [
             'tomo-helper=specfem_tomo_helper.cli:main',

--- a/specfem_tomo_helper/projection/utm_projection.py
+++ b/specfem_tomo_helper/projection/utm_projection.py
@@ -42,7 +42,7 @@ def define_utm_projection(utm_zone: int, hemisphere: str) -> pyproj.proj.Proj:
 
     Notes
     ----------
-    Using this function should be the preffered way to define the projection
+    Using this function should be the preferred way to define the projection
     from lat/lon to utm easting and northing. If desired, users can handle the
     projection themselves by defining a custom pyproj.proj.Proj object.
 

--- a/specfem_tomo_helper/templates/config_anisotropic_template.yaml
+++ b/specfem_tomo_helper/templates/config_anisotropic_template.yaml
@@ -3,6 +3,12 @@
 # Path to NetCDF model with anisotropic stiffness tensor components
 data_path: 'path/to/your/anisotropic_model.nc'  # Update with your actual model path
 
+# Basis for the local 3D cartesian coordinate system used in the netCDF model.
+# Should be a right-handed system defined by an ordered set of 3 directions -
+# east, west, north, south, up, down; combined using underscores into a string,
+# e.g., 'east_north_up', 'north_east_down', 'south_east_up'.
+basis: null
+
 # Grid spacing (meters)
 dx: 10000
 dy: 10000

--- a/specfem_tomo_helper/templates/config_anisotropic_template.yaml
+++ b/specfem_tomo_helper/templates/config_anisotropic_template.yaml
@@ -58,7 +58,7 @@ use_gui: true # Force GUI even if extent is set
 
 # Mesh generation options (same as isotropic)
 generate_mesh: true
-mesh_output_dir: './meshfem3D_files'
+mesh_output_dir: './DATA/meshfem3D_files'
 max_depth: 250.0  # in km
 dx_target_km: 10.0  # Might want larger elements for anisotropic models
 dz_target_km: 10.0
@@ -67,12 +67,12 @@ doubling_layers: [31.0, 80.0]  # in km
 
 # Topography generation options (same as isotropic)
 generate_topography: true
-topography_output_dir: './meshfem3D_files'
+topography_output_dir: './DATA/meshfem3D_files'
 slope_thresholds: [10, 15, 20]
 smoothing_sigma: 'auto'
 
 # Tomography output options
-tomo_output_dir: './tomo_files'
+tomo_output_dir: './DATA/tomo_files'
 float_format: '%.1f'  # Higher precision recommended for tensor components
 
 # Plotting options for anisotropic models

--- a/specfem_tomo_helper/templates/config_anisotropic_template.yaml
+++ b/specfem_tomo_helper/templates/config_anisotropic_template.yaml
@@ -73,7 +73,7 @@ smoothing_sigma: 'auto'
 
 # Tomography output options
 tomo_output_dir: './tomo_files'
-float_format: '%.8f'  # Higher precision recommended for tensor components
+float_format: '%.1f'  # Higher precision recommended for tensor components
 
 # Plotting options for anisotropic models
 plot_outer_shell: true

--- a/specfem_tomo_helper/templates/config_example_template.yaml
+++ b/specfem_tomo_helper/templates/config_example_template.yaml
@@ -28,7 +28,7 @@ use_gui: true # Force GUI even if extent is set
 
 # Mesh generation options
 generate_mesh: true
-mesh_output_dir: './meshfem3D_files'  # Directory for mesh files
+mesh_output_dir: './DATA/meshfem3D_files'  # Directory for mesh files
 max_depth: 250.0  # in km
 dx_target_km: 5.0
 dz_target_km: 5.0
@@ -37,12 +37,12 @@ doubling_layers: [31.0, 80.0]  # in km
 
 # Topography generation options
 generate_topography: true
-topography_output_dir: './meshfem3D_files'
+topography_output_dir: './DATA/meshfem3D_files'
 slope_thresholds: [10, 15, 20] # Diagnostic thresholds for slope in degrees. Lower value is used for 'auto' smoothing.
 smoothing_sigma: 'auto'  # Sigma for Gaussian smoothing of topography (default: 1, or 'auto' for adaptive smoothing)
 
 # Tomography output options
-tomo_output_dir: './tomo_files'  # Directory for tomography_model.xyz
+tomo_output_dir: './DATA/tomo_files'  # Directory for tomography_model.xyz
 
 # Plotting options
 plot_outer_shell: true

--- a/specfem_tomo_helper/utils/change_of_basis.py
+++ b/specfem_tomo_helper/utils/change_of_basis.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Transform between different bases for 3D cartesian coordinate systems.
+
+This module provides functions to:
+- Obtain reference coordinates for geographical directions.
+- Retrieve basis matrices for different basis systems.
+- Compute transformation matrices between different bases.
+- Transform symmetric stiffness matrices (represented as vectors) from one
+basis to another.
+
+Notes
+-----
+All transformations assume right-handed coordinate systems.
+"""
+
+from elasticmapper.core.rotation import rotation_mat_6d
+from elasticmapper.mapper_utils.change_of_basis import c_mat_of_t_mat
+from elasticmapper.mapper_utils.change_of_basis import t_mat_of_c_mat
+from elasticmapper.mapper_utils.utilities import v2sm, sm2v
+import numpy as np
+
+def reference_coordinates(direction):
+    """Coordinates for a vector pointing in a given geographical direction.
+
+    Function to return the reference coordinates for a vector pointing
+    in a given geographical direction with respect to a reference basis
+    defined as x -> south, y -> east, z -> up
+
+    Parameters
+    ----------
+    direction: str
+        "east", "west", "north", "south", "up", "down"
+
+    Returns
+    -------
+    b_vec: ndarray of shape (3,)
+        coordinates for the given direction in the reference basis
+
+    Raises
+    ------
+    AssertionError
+        If `direction` is not one of the supported values.
+        Error message: "Error: requested direction invalid"
+    """
+    assert direction in ["east", "west", "north", "south", "up", "down"],\
+        "Error: requested direction invalid"
+
+    if direction == "east":
+        b_vec = np.array([0, 1, 0])
+    elif direction == "west":
+        b_vec = np.array([0, -1, 0])
+    elif direction == "north":
+        b_vec = np.array([-1, 0, 0])
+    elif direction == "south":
+        b_vec = np.array([1, 0, 0])
+    elif direction == "up":
+        b_vec = np.array([0, 0, 1])
+    elif direction == "down":
+        b_vec = np.array([0, 0, -1])
+
+    return b_vec
+
+
+def get_basis(basis):
+    """Construct basis matrix for a 3D cartesian coordinate system.
+
+    Function to get the basis matrix for a 3D cartesian coordinate system
+    representing geographical directions with respect to a reference basis
+    defined as x -> south, y -> east, z -> up.
+
+    Parameters
+    ----------
+    basis: str
+        string defining the basis; should be a right-handed system defined by
+        an ordered set of 3 directions - east, west, north, south, up, down;
+        combined using underscores into a string,
+        e.g., 'east_north_up', 'north_east_down', 'south_east_up'
+
+    Returns
+    -------
+    b_mat: ndarray of shape (3, 3)
+        matrix of basis elements for the chosen basis, organized in columns;
+        each column corresponds to a basis vector.
+
+    Raises
+    ------
+    AssertionError
+        If `basis` is not one of the supported values.
+        Error message: "Error: requested basis '<basis>' is invalid"
+    """
+
+    assert basis in [
+    "east_north_up",   "east_south_down",   "east_up_south", "east_down_north",
+    "north_west_up",   "north_east_down",   "north_up_east", "north_down_west",
+    "west_south_up",   "west_north_down",   "west_up_north", "west_down_south",
+    "south_east_up",   "south_west_down",   "south_up_west", "south_down_east",
+    "up_south_east",     "up_north_west",   "up_east_north",   "up_west_south",
+    "down_north_east", "down_south_west", "down_east_south", "down_west_north"
+    ], f"Error: requested basis '{basis}' is invalid"
+
+    b_mat = np.zeros((3, 3))
+    directions = basis.split('_')
+    for i, direction in enumerate(directions):
+        b_mat[:, i] = reference_coordinates(direction)
+    return b_mat
+
+
+def get_transformation_matrix(basis_2, basis_1):
+    """Construct transformation matrix.
+
+    Function to return matrix that transforms a 3D vector from one basis
+    to another.
+
+    Parameters
+    ----------
+    basis_2: str
+        final basis
+    basis_1: str
+        initial basis
+
+    Returns
+    -------
+    transformation_mat: ndarray of shape (3, 3)
+        transformation matrix
+    """
+    b_mat_1 = get_basis(basis_1)
+    b_mat_2 = get_basis(basis_2)
+    transformation_mat = np.dot(np.linalg.inv(b_mat_2), b_mat_1)
+    return transformation_mat
+
+
+def transform(c_vec_1, basis_1):
+    """Transform a stiffness vector from one basis to another.
+
+    Function to transform vector representation of the symmetric stiffness
+    matrix from one reference basis to another.
+
+    Parameters
+    ----------
+    c_vec_1: ndarray of shape (21,)
+        vector to be transformed, represented in the initial basis
+    basis_1: str
+        initial basis of the vector, should be a right-handed system defined
+        by an ordered set of 3 directions - east, west, north, south, up, down;
+        combined using underscores into a string,
+        e.g., 'east_north_up', 'north_east_down', 'south_east_up'
+
+    Returns
+    -------
+    c_vec_2: ndarray of shape (21,)
+        vector transformed to the new basis, represented in the final basis
+    """
+    basis_2 = "east_north_up" # Basis definition in SPECFEM3D_cartesian
+
+    u_mat = get_transformation_matrix(basis_2, basis_1)
+    u_mat_6d = rotation_mat_6d(u_mat)
+
+    c_mat_1 = v2sm(c_vec_1)
+    t_mat_1 = t_mat_of_c_mat(c_mat_1)
+
+    t_mat_2 = np.dot(np.dot(u_mat_6d, t_mat_1), u_mat_6d.T)
+
+    c_mat_2 = c_mat_of_t_mat(t_mat_2)
+    c_vec_2 = sm2v(c_mat_2)
+
+    return c_vec_2

--- a/specfem_tomo_helper/utils/config_utils.py
+++ b/specfem_tomo_helper/utils/config_utils.py
@@ -93,6 +93,13 @@ def validate_config(config):
         if not isinstance(config[key], typ):
             raise ConfigValidationError(f"Config option '{key}' must be of type {typ}, got {type(config[key])}")
 
+    # Check if data_path exists
+    if not os.path.isfile(config['data_path']):
+        raise ConfigValidationError(
+            f"data_path '{config['data_path']}' "
+            f"does not exist or is not a file"
+        )
+
     # Early validation of extent (before UTM logic that uses it)
     if 'extent' in config and config['extent'] is not None:
         if not (isinstance(config['extent'], list) and len(config['extent']) == 4):

--- a/specfem_tomo_helper/utils/config_utils.py
+++ b/specfem_tomo_helper/utils/config_utils.py
@@ -92,7 +92,7 @@ def validate_config(config):
             raise ConfigValidationError(f"Missing required config option: {key}")
         if not isinstance(config[key], typ):
             raise ConfigValidationError(f"Config option '{key}' must be of type {typ}, got {type(config[key])}")
-    
+
     # Early validation of extent (before UTM logic that uses it)
     if 'extent' in config and config['extent'] is not None:
         if not (isinstance(config['extent'], list) and len(config['extent']) == 4):
@@ -140,6 +140,37 @@ def validate_config(config):
                 f"For anisotropic models, all 21 stiffness tensor components (c11-c66) plus density (rho) are required."
             )
 
+        # Check if 'basis' is provided and validate basis
+        if 'basis' not in config:
+            raise ConfigValidationError(
+                f"Missing required config option: "
+                f"'basis' for anisotropic models. "
+            )
+        else:
+            basis = config.get('basis')
+            allowed_basis_elements = [
+                'east', 'west', 'north', 'south', 'up', 'down'
+            ]
+            if basis is not None:
+                if not isinstance(basis, str):
+                    raise ConfigValidationError(
+                        f"Expected string or None, got {type(basis).__name__}"
+                    )
+
+                basis_elements = basis.split('_')
+                if len(basis_elements) != 3:
+                    raise ConfigValidationError(
+                        f"'{basis}' must consist of exactly three directions "
+                        f"separated by underscores. "
+                        f"Allowed directions are: {allowed_basis_elements}"
+                    )
+
+                for basis_element in basis_elements:
+                    if basis_element.lower() not in allowed_basis_elements:
+                        raise ConfigValidationError(
+                          f"Invalid direction '{basis_element}' in '{basis}'. "
+                          f"Allowed directions are: {allowed_basis_elements}"
+                        )
 
     # UTM validation logic
     utm_zone = config.get('utm_zone')

--- a/specfem_tomo_helper/utils/mesh_processor.py
+++ b/specfem_tomo_helper/utils/mesh_processor.py
@@ -421,7 +421,7 @@ class MeshProcessor:
         filename: str = "Mesh_Par_file"
     ) -> None:
         """
-        Write the Par_file with minimal user input, using default or inferred parameters.
+        Write the Mesh_Par_file with minimal user input, using default or inferred parameters.
 
         Parameters
         ----------

--- a/tests/test_anisotropic_workflow.py
+++ b/tests/test_anisotropic_workflow.py
@@ -225,4 +225,4 @@ class TestAnisotropicWorkflow:
             assert 'c66' in variables
             assert 'rho' in variables
             assert config['fill_nan'] == 'vertical'
-            assert config['float_format'] == '%.8f'
+            assert config['float_format'] == '%.1f'

--- a/tests/test_anisotropic_workflow.py
+++ b/tests/test_anisotropic_workflow.py
@@ -65,6 +65,7 @@ class TestAnisotropicWorkflow:
         # Create a complete anisotropic config
         anisotropic_config = {
             'data_path': '/tmp/test.nc',  # Will be mocked
+            'basis': None,
             'dx': 10000,
             'dy': 10000,
             'dz': 1000,
@@ -92,6 +93,7 @@ class TestAnisotropicWorkflow:
         """Test config validation fails for incomplete anisotropic models."""
         incomplete_config = {
             'data_path': '/tmp/test.nc',
+            # Missing 'basis'
             'dx': 10000,
             'dy': 10000,
             'dz': 1000,
@@ -109,10 +111,26 @@ class TestAnisotropicWorkflow:
             
             assert "missing required components" in str(excinfo.value)
 
+        incomplete_config['variable'] = [
+            'c11', 'c12', 'c13', 'c14', 'c15', 'c16',
+             'c22', 'c23', 'c24', 'c25', 'c26',
+             'c33', 'c34', 'c35', 'c36',
+             'c44', 'c45', 'c46',
+             'c55', 'c56',
+             'c66', 'rho'
+        ]
+
+        with patch('os.path.isfile', return_value=True):
+            with pytest.raises(ConfigValidationError) as excinfo:
+                validate_config(incomplete_config)
+
+            assert "Missing required config option" in str(excinfo.value)
+
     def test_anisotropic_plot_color_by(self):
         """Test plot_color_by validation for anisotropic models."""
         anisotropic_config = {
             'data_path': '/tmp/test.nc',
+            'basis': None,
             'dx': 10000,
             'dy': 10000,
             'dz': 1000,
@@ -196,7 +214,10 @@ class TestAnisotropicWorkflow:
             # Check content of generated file
             with open(output_file, 'r') as f:
                 config = yaml.safe_load(f)
-            
+
+            # Verify it contains the parameter basis
+            assert 'basis' in config
+
             # Verify it contains all anisotropic components
             variables = config['variable']
             assert len(variables) == 22  # 21 Cij + rho

--- a/tests/test_change_of_basis.py
+++ b/tests/test_change_of_basis.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Test the change of basis functionality in specfem_tomo_helper."""
+
+import numpy as np
+from specfem_tomo_helper.utils.change_of_basis import transform
+
+# These test stiffness values are taken from Brown et al. 2016 and are in GPa
+C_VEC_BROWN = np.array([68.3, 32.2, 30.4, 4.9, -2.3, -0.9,
+                        184.3, 5.0, -4.4, -7.8, -6.4,
+                        180.0, -9.2, 7.5, -9.4,
+                        25.0, -2.4, -7.2,
+                        26.9, 0.6,
+                        33.6])
+
+C_VEC_NORTH_EAST_DOWN = C_VEC_BROWN
+
+C_VEC_EAST_NORTH_UP = np.array([184.3, 32.2,  5.0,   7.8,  4.4, -6.4,
+                                68.3, 30.4, 2.3, -4.9, -0.9,
+                                180.0, -7.5, 9.2, -9.4,
+                                26.9, -2.4, -0.6,
+                                25.0, 7.2,
+                                33.6])
+
+def test_basis_change():
+    assert np.allclose(
+        transform(C_VEC_NORTH_EAST_DOWN, 'north_east_down'),
+        C_VEC_EAST_NORTH_UP,
+    ), "basis change from 'north_east_down' to 'east_north_up' failed"


### PR DESCRIPTION
This pull request adds the feature to transform the basis of `anisotropic models` to that used by `specfem3d_cartesian`. For this users will need to fill in the value of the parameter `basis` in the config yaml file with the basis in which the input netcdf model is defined, e.g., `'east_north_up'`, `'north_east_down'`, `'south_east_up'`. If the value of the entered `basis` parameter is not `null` or `'east_north_up'` (`specfem3d_cartesian` basis), it will automatically trigger a basis transformation of the stiffness parameters before the `tomography_model.xyz` is written out.

Resolves #23.